### PR TITLE
Update Example Query

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ query PageQuery {
         edges {
             node {
                 created_at
-                text
+                full_text
                 user {
                     name
                 }


### PR DESCRIPTION
In `tweet_mode: extended`, `text` is not a response param, (`full_text` is). Just updating to match the plugin options example with the query example.